### PR TITLE
Do not detach HEAD when that is not possible

### DIFF
--- a/backup_bundle.py
+++ b/backup_bundle.py
@@ -712,11 +712,17 @@ class Restoration:
         :param new_references: The new references to update the local repository to.
         :return: True iff HEAD should be detached before (force-)fetching the updates.
         """
-        if self.current_branch_name:
+        if not self._is_repo_bare and self.current_branch_name:
             new_ref_for_current_branch = [
                 ref for ref in new_references if ref.ref == f"refs/heads/{self.current_branch_name}"
             ]
-            if self.force and not new_ref_for_current_branch:
+
+            # If there is no new reference for the current branch and force is used, then we should detach HEAD first,
+            # if that is possible.
+            #
+            # The initial branch of a new and empty repository can't be switched away from, but may be overwritten
+            # for free. The git call checks if the repository has a HEAD at all to detect the empty repository.
+            if self.force and not new_ref_for_current_branch and try_call_git(["rev-parse", "HEAD"], cwd=self.repo):
                 # This will delete the current branch. HEAD needs to be detached first.
                 return True
         return False

--- a/backup_bundle_tests.py
+++ b/backup_bundle_tests.py
@@ -271,7 +271,14 @@ def assert_repos_not_equal(repo1: Path, repo2: Path) -> None:
     assert set(refs1) != set(refs2)
 
 
-def create_repo(repo: Path | str, *, clone: Path | str | None = None, bare: bool = False, mirror: bool = False) -> Path:
+def create_repo(
+    repo: Path | str,
+    *,
+    clone: Path | str | None = None,
+    bare: bool = False,
+    mirror: bool = False,
+    initial_branch: str | None = None,
+) -> Path:
     """
     Create a git repository in repo.
 
@@ -279,6 +286,7 @@ def create_repo(repo: Path | str, *, clone: Path | str | None = None, bare: bool
     :param clone: If set, clone from this source.
     :param bare: Create a bare repository.
     :param mirror: Create a mirrored clone.
+    :param initial_branch: If set, the name of the initial branch of the repository.
     :returns: `repo`
     """
     if isinstance(repo, str):
@@ -288,6 +296,7 @@ def create_repo(repo: Path | str, *, clone: Path | str | None = None, bare: bool
     repo.mkdir(parents=True, exist_ok=True)
     options: list[str] = []
     if clone is not None:
+        assert initial_branch is None, "initial_branch makes no sense if cloning"
         if mirror:
             options = ["--mirror"]
         elif bare:
@@ -297,6 +306,8 @@ def create_repo(repo: Path | str, *, clone: Path | str | None = None, bare: bool
         assert not mirror, "mirror makes no sense if not cloning"
         if bare:
             options = ["--bare"]
+        if initial_branch:
+            options += ["--initial-branch", initial_branch]
         call_git(["init", *options, "."], cwd=repo)
     return repo
 
@@ -2425,5 +2436,43 @@ def test_restore_strict_order_without_force_does_not_stop_on_reference_only_bund
 
     # Restoring the directory works as expected: the reference update bundles[0] is effectively skipped
     backup_bundle_main("restore", target, bundle_dir, "--strict-order", "--delete-files")
+
+    assert_repos_equal(origin, target)
+
+
+@pytest.mark.parametrize(
+    ("bare", "empty_repo"),
+    [
+        (True, False),
+        (False, False),
+        (True, True),
+        (False, True),
+    ],
+)
+def test_restore_to_repo_with_different_main_branch(*, bare: bool, empty_repo: bool) -> None:
+    """
+    Verify that restoring into a repository works correctly, even if the restored data does not contain the same default
+    (main) branch as the repository being restored to.
+
+    :param bare: Whether the new repository is initialized as a bare repository.
+    :param empty_repo: whether the new repository will be entirely empty.
+    """
+    bundle = Path("bundle.bundle")
+    second_bundle = Path("second.bundle")
+
+    origin = create_repo("origin", initial_branch="initial")
+    add_commits(origin, count=3)
+
+    backup_bundle_main("create", origin, bundle)
+
+    target = create_repo("target", bare=bare, initial_branch="somethingelse")
+    if not empty_repo:
+        # Add commits using a create/restore to allow adding commits to a bare repository
+        second_origin = create_repo("second_origin", initial_branch="somethingelse")
+        add_commits(second_origin, count=2)
+        backup_bundle_main("create", second_origin, second_bundle)
+        backup_bundle_main("restore", target, second_bundle, "--force", "--prune")
+
+    backup_bundle_main("restore", target, bundle, "--force", "--prune")
 
     assert_repos_equal(origin, target)


### PR DESCRIPTION
In a bare repository or a completely empty repository it is not possible to detach HEAD. Nor is it needed, even if the current branch would be deleted.